### PR TITLE
Fix contact field on snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -2,7 +2,7 @@ name: charmed-openstack-exporter
 base: core22
 summary: OpenStack Exporter for Prometheus
 license: MIT
-contact: Solutions Engineering <solutions-engineering@lists.canonical.com>
+contact: solutions-engineering@lists.canonical.com
 description: |
   The OpenStack exporter, exports Prometheus metrics from a running OpenStack
   cloud for consumption by prometheus.


### PR DESCRIPTION
Release of the snap is failing because it is complaining about the contact field. Contact link must have one of http|https schemes or it must be an email address.