### PR TITLE
Update snap for Ubuntu 26.04 and Gazpacho 2026.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: charmed-openstack-exporter
-base: core24
+base: core26
 summary: OpenStack Exporter for Prometheus
 license: MIT
 contact: solutions-engineering@lists.canonical.com
@@ -124,7 +124,8 @@ source-code: https://github.com/canonical/charmed-openstack-exporter-snap
 issues: https://github.com/canonical/charmed-openstack-exporter-snap/issues
 adopt-info: openstack-exporter
 confinement: strict
-grade: stable
+build-base: devel
+grade: devel
 
 platforms:
   amd64:
@@ -150,10 +151,7 @@ parts:
     plugin: go
     source: https://github.com/openstack-exporter/openstack-exporter.git
     source-type: git
-    # Please see https://github.com/canonical/charmed-openstack-exporter-snap/issues/37
-    # Pin to a specific commit until upstream fixes collection of openstack_nova metrics
-    # v1.7.0-39-g20f5bdd revision
-    source-commit: 20f5bdd0e40a2ca5512471f86fdf2981f8caf350
+    source-tag: v1.8.0-alpha
     build-snaps:
       - go
     # override pull to read VERSION because working dir is root of source repo

--- a/tox.ini
+++ b/tox.ini
@@ -26,11 +26,8 @@ commands =
     isort --check --diff --color .
     flake8
 deps =
-    # Pin black and isort because newer versions of black no longer support Python 3.8 and 3.9.
-    # This ensures consistent formatting and linting across all CI-tested Python versions
-    # (3.8, 3.10, and 3.12).
-    black==24.8.0
-    isort==5.13.2
+    black
+    isort
     colorama
     flake8
     flake8-colors
@@ -46,8 +43,8 @@ commands =
     black .
     isort .
 deps =
-    black==24.8.0
-    isort==5.13.2
+    black
+    isort
 
 [testenv:unit]
 setenv =


### PR DESCRIPTION
Target Ubuntu 26.04 LTS and OpenStack Gazpacho:
- Bump snap base from core24 to core26
- Add build-base: devel until core26 is stable
- Set grade to devel for development builds
- Update openstack-exporter from pinned commit to v1.8.0-alpha tag
- Remove commit pin workaround for nova metrics issue (#37, now closed)
- Unpin black and isort versions (old pins for Python 3.8/3.9 compat)